### PR TITLE
Allow deferreds to use clojure.core deref timeouts

### DIFF
--- a/src/manifold/deferred.clj
+++ b/src/manifold/deferred.clj
@@ -249,9 +249,10 @@
         (try
           (on-realized ~'this f# f#)
           (.await latch# ~@await-args)
-          (if (identical? ::success ~'state)
-            ~'val
-            (throw ~'val))
+          (cond
+            (identical? ::success ~'state) ~'val
+            (instance? Throwable ~'val) (throw ~'val)
+            :else ~timeout-value)
           ~@(when-not (empty? await-args)
               `((catch TimeoutException _#
                   ~timeout-value)))))))

--- a/test/manifold/deferred_test.clj
+++ b/test/manifold/deferred_test.clj
@@ -139,7 +139,11 @@
     (is (= true (cancel-listener! d l)))
     (is (= true (success! d :foo)))
     (is (= :foo @(capture-success d)))
-    (is (= false (cancel-listener! d l)))))
+    (is (= false (cancel-listener! d l))))
+
+  ; timeouts
+  (let [d (deferred)]
+    (is (= ::timeout (deref d 10 ::timeout)))))
 
 ;;;
 


### PR DESCRIPTION
Prior to this `(deref (manifold.deferred/deferred) 10 :ok)` would throw a NullPointerException. This patch seems like it keeps all the prior behavior of using the `val` to hold a TimeoutException and whatnot, but allows this normal use-case to work as well.