### PR TITLE
Fix handling of realized errors in loop

### DIFF
--- a/src/manifold/deferred.clj
+++ b/src/manifold/deferred.clj
@@ -989,13 +989,19 @@
                             nil))]
              (if (deferred? ~x-sym)
                (if (realized? ~x-sym)
-                 (let [~x-sym @~x-sym]
-                   (if (instance? Recur ~x-sym)
-                     (~'recur
-                       ~@(map
-                           (fn [n] `(nth @~x-sym ~n))
-                           (range (count vars))))
-                     (success! result# ~x-sym)))
+                 (when (try
+                         @~x-sym
+                         true
+                         (catch Throwable e#
+                           (error! result# e#)
+                           false))
+                   (let [~x-sym @~x-sym]
+                     (if (instance? Recur ~x-sym)
+                       (~'recur
+                         ~@(map
+                             (fn [n] `(nth @~x-sym ~n))
+                             (range (count vars))))
+                       (success! result# ~x-sym))))
                  (on-realized (chain ~x-sym)
                    (fn [x#]
                      (if (instance? Recur x#)


### PR DESCRIPTION
This handles the case of the `loop` body producing a realized error.

Before:
```clojure
user=> (d/loop [] (d/error-deferred (RuntimeException. "boom")))
RuntimeException boom  user/eval14824/this--1884--auto----14825/fn--14826 (form-init5955528930188478346.clj:2)
```

After:
```clojure
user=> (d/loop [] (d/error-deferred (RuntimeException. "boom")))
<< ERROR: #<RuntimeException java.lang.RuntimeException: boom> >>
```