### PR TITLE
Fix delivery of all consumers on default stream close

### DIFF
--- a/src/manifold/stream/default.clj
+++ b/src/manifold/stream/default.clj
@@ -63,7 +63,8 @@
               (try
                 (d/success! (.deferred c) (.default-val c))
                 (catch Throwable e
-                  (log/error e "error in callback")))))
+                  (log/error e "error in callback")))
+              (recur)))
           (.markClosed this)
           (when (s/drained? this)
             (.markDrained this))))))


### PR DESCRIPTION
Just a missing `recur`! I put the `recur` outside of the try/catch, since I'm assuming you'd want to deliver all of the consumer values even if one of them throws.

I also added a test case which is analogous to the initial circumstances that led me to see the bugged behavior. If there's a more concise or direct way you'd like to test this, let me know.