### PR TITLE
on-realized now returns the deferred

### DIFF
--- a/src/manifold/deferred.clj
+++ b/src/manifold/deferred.clj
@@ -80,7 +80,8 @@
   "Registers callbacks with the manifold deferred for both success and error outcomes."
   [x on-success on-error]
   `(let [^manifold.deferred.IDeferred x# ~x]
-     (.onRealized x# ~on-success ~on-error)))
+     (.onRealized x# ~on-success ~on-error)
+     ~x))
 
 (definline deferred?
   "Returns true if the object is an instance of a Manifold deferred."


### PR DESCRIPTION
rather than whatever .onRealized returns as this is a bit arbitrary

Also noticed that there were a few cljfmt errors but I left them as my change didn't seem to have broken anything...