### PR TITLE
Take into account the max-backlog parameter in throttle fn

### DIFF
--- a/src/manifold/stream.clj
+++ b/src/manifold/stream.clj
@@ -995,7 +995,7 @@
            (fn [result]
              (when result
                (let [elapsed (double (- (System/currentTimeMillis) read-start))
-                     backlog' (+ backlog (- (/ elapsed period) 1))]
+                     backlog' (min (+ backlog (- (/ elapsed period) 1)) max-backlog)]
                  (if (<= 1 backlog')
                    (- backlog' 1.0)
                    (d/timeout! (d/deferred) (- period elapsed) 0.0)))))


### PR DESCRIPTION
As reported by David Smith on https://groups.google.com/forum/#!topic/aleph-lib/z-DwbnggpwA it looks like max-backlog parameter is not taken into account.

Here is my attempt to fix it, some manual tests seems to do the trick but I'm not 100% confident about the side effects of it.