### PR TITLE
add `hasActive` method to IEventBus

### DIFF
--- a/src/manifold/bus.clj
+++ b/src/manifold/bus.clj
@@ -18,7 +18,8 @@
   (subscribe [topic])
   (downstream [topic])
   (publish [topic message])
-  (isActive [topic]))
+  (isActive [topic])
+  (hasActive []))
 
 (definline publish!
   "Publishes a message on the bus, returning a deferred result representing the message
@@ -42,6 +43,11 @@
   "Returns `true` if there are any subscribers to `topic`."
   [bus topic]
   `(.isActive ~(with-meta bus {:tag "manifold.bus.IEventBus"}) ~topic))
+
+(definline has-active?
+  "Returns `true` if there are any subscribers."
+  [bus]
+  `(.hasActive ~(with-meta bus {:tag "manifold.bus.IEventBus"})))
 
 (defn- conj' [ary x]
   (if (nil? ary)
@@ -114,4 +120,7 @@
           (seq (.get topic->subscribers topic)))
 
         (isActive [_ topic]
-          (boolean (.get topic->subscribers topic)))))))
+          (boolean (.get topic->subscribers topic)))
+
+        (hasActive [_]
+          (not (.isEmpty topic->subscribers)))))))

--- a/test/manifold/bus_test.clj
+++ b/test/manifold/bus_test.clj
@@ -12,7 +12,9 @@
     (is (= false @(b/publish! b :bar 2)))
     (let [s (b/subscribe b :foo)
           d (b/publish! b :foo 2)]
+      (is (b/has-active? b))
       (is (= 2 @(s/take! s)))
       (is (= true @d))
       (s/close! s)
-      (is (= false @(b/publish! b :foo 2))))))
+      (is (= false @(b/publish! b :foo 2)))
+      (is (not (b/has-active? b))))))


### PR DESCRIPTION
Sometimes it's valuable to know if there are any subscribers on the bus at all. Currently the subscription map on the bus isn't exposed in any way, so it's impossible without knowing all of the topics.

Please consider adding either something like `hasActive` or a way to access the underlying subscription store.