### PR TITLE
Make java 8 extensions opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,24 @@ nil
 
 Manifold can use any transducer, which are applied via `transform`.  It also provides stream-specific transforms, including `zip`, `reduce`, `buffer`, `batch`, and `throttle`.  [To learn more about streams, go here](/docs/stream.md).
 
+### Java 8 extensions
+
+Manifold includes support for a few classes introduced in Java 8:
+`java.util.concurrent.CompletableFuture` and `java.util.stream.BaseStream`.
+Support for Java 8 is detected automatically at compile time; if you are
+AOT compiling Manifold on Java 8 or newer, and will be running the compiled
+jar with a Java 7 or older JRE, you will need to disable this feature, by
+setting the JVM option `"manifold.disable-jvm8-primitives"`, either at the
+command line with
+
+    -Dmanifold.disable-jvm8-primitives=true
+
+or by adding
+
+    :jvm-opts ["-Dmanifold.disable-jvm8-primitives=true"]
+
+to your application's project.clj.
+
 ### license
 
 Copyright © 2014 Zach Tellman

--- a/src/manifold/utils.clj
+++ b/src/manifold/utils.clj
@@ -118,8 +118,11 @@
     `(do ~@body)))
 
 (defmacro when-class [class & body]
-  (when (try
-          (Class/forName (name class))
-          (catch Throwable e
-            ))
-    `(do ~@body)))
+  (let [disable-property (System/getProperty "manifold.disable-jvm8-primitives")
+        disabled? (and disable-property (not= disable-property "false"))]
+    (when (and (not disabled?)
+            (try
+              (Class/forName (name class))
+              (catch Throwable e
+                )))
+      `(do ~@body))))


### PR DESCRIPTION
If they are detected automatically, it becomes impossible to
cross-compile from a java 8 build environment to a java 7 (or lower)
deployment environment.

Instead, if you care about java 8 extensions, you can call
manifold.java8/enable-java8-extensions! at runtime, during your
program startup. This is safe whether you are running java 8 or
not: if an older runtime is detected, the extensions will not be
enabled.