### PR TITLE
Fix param name

### DIFF
--- a/src/manifold/stream.clj
+++ b/src/manifold/stream.clj
@@ -475,8 +475,8 @@
 
 (defn connect-via
   "Feeds all messages from `src` into `callback`, with the understanding that they will
-   eventually be propagated into `dst` in some form.  The return value of `f` should be
-   a deferred yielding either `true` or `false`."
+   eventually be propagated into `dst` in some form.  The return value of `callback`
+   should be a deferred yielding either `true` or `false`."
   ([src callback dst]
     (connect-via src callback dst nil))
   ([src callback dst options]


### PR DESCRIPTION
Also, I'm trying to understand how `connect-via` works. Is it "if callback returns deferred false, drops on floor; otherwise passes on to provided sink"? If so, perhaps I should reword the docstring as well; the wording reads to me as if this passing-on happens unconditionally right now.