### PR TITLE
Do not ignore the thread-factory if provided

### DIFF
--- a/src/manifold/executor.clj
+++ b/src/manifold/executor.clj
@@ -72,7 +72,7 @@
   "Returns a `java.util.concurrent.ExecutorService`, using [Dirigiste](https://github.com/ztellman/dirigiste).
 
    |:---|:----
-   | `thread-factory` | an optional `java.util.concurrent.ThreadFactory` that creates the executor's thrreads. |
+   | `thread-factory` | an optional `java.util.concurrent.ThreadFactory` that creates the executor's threads. |
    | `queue-length` | the maximum number of pending tasks before `.execute()` begins throwing `java.util.concurrent.RejectedExecutionException`, defaults to `0`.
    | `stats-callback` | a function that will be invoked every `control-period` with the relevant statistics for the executor.
    | `sample-period` | the interval, in milliseconds, between sampling the state of the executor for resizing and gathering statistics, defaults to `25`.
@@ -99,11 +99,13 @@
   (let [executor-promise (promise)
         thread-count (atom 0)
         factory (swap! factory-count inc)
-        thread-factory (manifold.executor/thread-factory
-                         #(str "manifold-pool-" factory "-" (swap! thread-count inc))
-                         (if onto?
-                           executor-promise
-                           (deliver (promise) nil)))
+        thread-factory (if thread-factory
+                         thread-factory
+                         (manifold.executor/thread-factory
+                           #(str "manifold-pool-" factory "-" (swap! thread-count inc))
+                           (if onto?
+                             executor-promise
+                             (deliver (promise) nil))))
         ^Executor$Controller c controller
         metrics (if (identical? :none metrics)
                   (EnumSet/noneOf Stats$Metric)

--- a/test/manifold/executor_test.clj
+++ b/test/manifold/executor_test.clj
@@ -23,11 +23,11 @@
         factory (e/thread-factory
                   #(str pool-prefix (swap! thread-count inc))
                   (deliver (promise) nil))
-        thread-count 1
+        initial-thread-count 0
         executor (e/instrumented-executor
                    {:controller           controller
                     :thread-factory       factory
-                    :initial-thread-count thread-count
+                    :initial-thread-count initial-thread-count
                     })]
     (is (= false (.isShutdown ^Executor executor)))
-    (is (>= (count (filter-threads pool-prefix)) thread-count))))
+    (is (>= (count (filter-threads pool-prefix)) initial-thread-count))))

--- a/test/manifold/executor_test.clj
+++ b/test/manifold/executor_test.clj
@@ -29,5 +29,5 @@
                     :thread-factory       factory
                     :initial-thread-count thread-count
                     })]
-    (.execute ^Executor executor #(prn "Hello world!"))
+    (is (= false (.isShutdown ^Executor executor)))
     (is (>= (count (filter-threads pool-prefix)) thread-count))))

--- a/test/manifold/executor_test.clj
+++ b/test/manifold/executor_test.clj
@@ -1,0 +1,33 @@
+(ns manifold.executor-test
+  (:require
+    [clojure.test :refer :all]
+    [clojure.string :as str]
+    [manifold.executor :as e])
+  (:import
+    [io.aleph.dirigiste
+     Executors
+     Executor]
+    [java.lang.management
+     ManagementFactory
+     ThreadInfo]))
+
+(defn filter-threads [name-prefix]
+  (let [thread-mx-bean (ManagementFactory/getThreadMXBean)
+        thread-infos (into [] (.getThreadInfo thread-mx-bean (.getAllThreadIds thread-mx-bean)))]
+    (filter (fn [^ThreadInfo info] (str/starts-with? (.getThreadName info) name-prefix)) thread-infos)))
+
+(deftest test-instrumented-executor-uses-thread-factory
+  (let [controller (Executors/utilizationController 0.95 1)
+        thread-count (atom 0)
+        pool-prefix "my-pool-prefix-"
+        factory (e/thread-factory
+                  #(str pool-prefix (swap! thread-count inc))
+                  (deliver (promise) nil))
+        thread-count 1
+        executor (e/instrumented-executor
+                   {:controller           controller
+                    :thread-factory       factory
+                    :initial-thread-count thread-count
+                    })]
+    (.execute ^Executor executor #(prn "Hello world!"))
+    (is (>= (count (filter-threads pool-prefix)) thread-count))))

--- a/test/manifold/executor_test.clj
+++ b/test/manifold/executor_test.clj
@@ -1,33 +1,23 @@
 (ns manifold.executor-test
   (:require
     [clojure.test :refer :all]
-    [clojure.string :as str]
     [manifold.executor :as e])
   (:import
     [io.aleph.dirigiste
      Executors
      Executor]
-    [java.lang.management
-     ManagementFactory
-     ThreadInfo]))
-
-(defn filter-threads [name-prefix]
-  (let [thread-mx-bean (ManagementFactory/getThreadMXBean)
-        thread-infos (into [] (.getThreadInfo thread-mx-bean (.getAllThreadIds thread-mx-bean)))]
-    (filter (fn [^ThreadInfo info] (str/starts-with? (.getThreadName info) name-prefix)) thread-infos)))
+    [java.util.concurrent
+     LinkedBlockingQueue]))
 
 (deftest test-instrumented-executor-uses-thread-factory
-  (let [controller (Executors/utilizationController 0.95 1)
-        thread-count (atom 0)
-        pool-prefix "my-pool-prefix-"
-        factory (e/thread-factory
-                  #(str pool-prefix (swap! thread-count inc))
+  (let [thread-count (atom 0)
+        threadpool-prefix "my-pool-prefix-"
+        thread-factory (e/thread-factory
+                  #(str threadpool-prefix (swap! thread-count inc))
                   (deliver (promise) nil))
-        initial-thread-count 0
         executor (e/instrumented-executor
-                   {:controller           controller
-                    :thread-factory       factory
-                    :initial-thread-count initial-thread-count
-                    })]
-    (is (= false (.isShutdown ^Executor executor)))
-    (is (>= (count (filter-threads pool-prefix)) initial-thread-count))))
+                   {:controller     (Executors/utilizationController 0.95 1)
+                    :thread-factory thread-factory})
+        thread-names (LinkedBlockingQueue. 1)]
+    (.execute ^Executor executor #(.put thread-names (.getName (Thread/currentThread))))
+    (is (= (.take thread-names) (str threadpool-prefix @thread-count)))))

--- a/test/manifold/executor_test.clj
+++ b/test/manifold/executor_test.clj
@@ -23,4 +23,4 @@
                     :thread-factory thread-factory})
         thread-names (LinkedBlockingQueue. 1)]
     (.execute ^Executor executor #(.put thread-names (.getName (Thread/currentThread))))
-    (is (= (.take thread-names) (str threadpool-prefix @thread-count)))))
+    (is (contains? #{(str threadpool-prefix 1) (str threadpool-prefix 2)} (.take thread-names)))))


### PR DESCRIPTION
According to the doc string of instrumented-executor you can pass in your own thread factory for spawning new threads. However, my test demonstrates that it is not used at all in the function body.

This commit fixes the issue and also fixes a typo in the doc string.