### PR TITLE
Make documentation buildable

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
                    :benchmark :benchmark
                    :stress #(or (:stress %) (= :stress (:tag %)))
                    :all (constantly true)}
-  :plugins [[codox "0.8.10"]
+  :plugins [[lein-codox "0.9.4"]
             [lein-jammin "0.1.1"]
             [ztellman/lein-cljfmt "0.1.10"]]
   :cljfmt {:indents {#".*" [[:inner 0]]}}


### PR DESCRIPTION
Changes the codox plugin to lein-codox and changes the version to one available on clojars. See #68.