### PR TITLE
the stack size of some thread-factories are too small.

### DIFF
--- a/src/manifold/executor.clj
+++ b/src/manifold/executor.clj
@@ -184,7 +184,8 @@
           (utilization-executor 0.95 Integer/MAX_VALUE
             {:thread-factory (thread-factory
                                #(str "manifold-wait-" (swap! cnt inc))
-                               (deliver (promise) nil))
+                               (deliver (promise) nil)
+                               1e2)
              :stats-callback (fn [stats]
                                (doseq [f @wait-pool-stats-callbacks]
                                  (try

--- a/src/manifold/executor.clj
+++ b/src/manifold/executor.clj
@@ -184,8 +184,7 @@
           (utilization-executor 0.95 Integer/MAX_VALUE
             {:thread-factory (thread-factory
                                #(str "manifold-wait-" (swap! cnt inc))
-                               (deliver (promise) nil)
-                               1e2)
+                               (deliver (promise) nil))
              :stats-callback (fn [stats]
                                (doseq [f @wait-pool-stats-callbacks]
                                  (try
@@ -215,8 +214,7 @@
           (utilization-executor 0.95 Integer/MAX_VALUE
             {:thread-factory (thread-factory
                                #(str "manifold-execute-" (swap! cnt inc))
-                               (deliver (promise) nil)
-                               1e2)
+                               (deliver (promise) nil))
              :stats-callback (fn [stats]
                                (doseq [f @execute-pool-stats-callbacks]
                                  (try


### PR DESCRIPTION
wait-pool-promise and execute-pool-promise have their own
thread-factory and the stack size is specified as 1e2(100).
It is too small.

my program suddenly becomes unstable (StackOverflowError occurs in some cases)
after upgrading 'aleph' to the newest 0.4.1 (which uses manifold 0.1.4),
so I noticed this problem. 

Changes to never assign a stack size for the thread-factories,
so they will use JVM-default stack size, and users will be able
to change it through a java option (-Xss).

In manifold 0.1.4, a bug where a :thread-factory option is
ignored in a instrumented-executor function is fixed, then
this problem suddenly be appeared. Before the bug-fix on 0.1.4,
the thread-factories simplly never had been used, so this problem
never occurred.