### PR TITLE
d/finally function doesn't work in some cases

### DIFF
--- a/src/manifold/deferred.clj
+++ b/src/manifold/deferred.clj
@@ -1000,10 +1000,15 @@
         x
         (catch Throwable e
           (error-deferred e)))
-      (chain' x
-        (fn [x']
-          (f)
-          x')))
+      (-> x
+          (chain'
+           (fn [x']
+             (f)
+             x'))
+          (catch'
+              (fn [e]
+                (f)
+                (throw e)))))
     (try
       (f)
       x

--- a/test/manifold/deferred_test.clj
+++ b/test/manifold/deferred_test.clj
@@ -227,6 +227,16 @@
       (.obtrudeException f (Exception.))
       (is (thrown? Exception (-> f d/->deferred deref))))))
 
+(deftest test-finally
+  (let [target-d (d/deferred)
+        d (d/deferred)
+        fd (d/finally
+             d
+             (fn []
+               (d/success! target-d ::delivered)))]
+    (d/error! d (Exception.))
+    (is (= ::delivered (deref target-d 0 ::not-delivered)))))
+
 ;;;
 
 (deftest ^:benchmark benchmark-chain


### PR DESCRIPTION
The implementation of `d/finally'` function seems to be not strictly correct. In particular, [this part](https://github.com/ztellman/manifold/blob/57d83fd993f6824cf60b1100ec6742e35078d6d6/src/manifold/deferred.clj#L1003-L1006). Obviously, if `x` is error deferred, the function with which it is chained isn't going to be called.

Test that reproduces the issue along with the fix are added.