### PR TITLE
Test exposing the broken arity of stream->seq

### DIFF
--- a/test/manifold/stream_test.clj
+++ b/test/manifold/stream_test.clj
@@ -94,9 +94,9 @@
              (utils/when-class java.util.stream.BasicStream
                (run-source-test #(-> % java.util.ArrayList. .stream)))]]
     (when f
-      (= (range 100) (-> (range 100) f s/->source s/stream->seq))))
-
-  )
+      (= (range 100) (-> (range 100) f s/->source s/stream->seq)))
+    (when f
+      (= (range 100) (-> (range 100) f s/->source (s/stream->seq 10))))))
 
 ;;;
 


### PR DESCRIPTION
This is just a test without a fix.

Currently `stream->seq` with the timeout arity is broken for streams returned from `->source` (at least) because `try-take!` returns a value instead of a deferred.

I haven't traced the failure further, but it seems to be because of the `blocking?` flag in the `IEventSource/take` treated differently for `stream/->source`.