### PR TITLE
Fix callback downstream to adhere to the protocol

### DIFF
--- a/src/manifold/stream.clj
+++ b/src/manifold/stream.clj
@@ -447,7 +447,8 @@
   (description [_]
     {:type "callback"})
   (downstream [_]
-    (when downstream [downstream]))
+    (when downstream
+      [[(description downstream) downstream]]))
   IEventSink
   (put [this x _]
     (try


### PR DESCRIPTION
The `downstream` of Callback returns a different thing than all the other `IEventStream/downstream` implementations.