### PR TITLE
Add deferred/alt

### DIFF
--- a/src/manifold/deferred.clj
+++ b/src/manifold/deferred.clj
@@ -1084,6 +1084,52 @@
     (map #(or (->deferred % nil) %))
     (apply zip')))
 
+;; same technique as clojure.core.async/random-array
+(defn- random-array [n]
+  (let [a (int-array n)]
+    (clojure.core/loop [i 1]
+      (if (= i n)
+        a
+        (let [j (rand-int (inc i))]
+          (aset a i (aget a j))
+          (aset a j i)
+          (recur (inc i)))))))
+
+(defn alt'
+  "Like `alt`, but only unwraps Manifold deferreds."
+  [& vals]
+  (let [d (deferred)
+        cnt (count vals)
+        ^ints idxs (random-array cnt)]
+    (clojure.core/loop [i 0]
+      (when (< i cnt)
+        (let [i' (aget idxs i)
+              x (nth vals i')]
+          (if (deferred? x)
+            (success-error-unrealized x
+              val (success! d val)
+              err (error! d err)
+              (do (on-realized (chain' x)
+                    #(success! d %)
+                    #(error! d %))
+                  (recur (inc i))))
+            (success! d x)))))
+    d))
+
+(defn alt
+  "Takes a list of values, some of which may be deferrable, and returns a
+  deferred that will yield the value which was realized first.
+
+    @(alt 1 2) => 1
+    @(alt (future (Thread/sleep 1) 1)
+          (future (Thread/sleep 1) 2)) => 1 or 2 depending on the thread scheduling
+
+  Values appearing earlier in the input are preferred."
+  [& vals]
+  (->> vals
+       (map #(or (->deferred % nil) %))
+       (apply alt')))
+
 (defn timeout!
   "Takes a deferred, and sets a timeout on it, such that it will be realized as `timeout-value`
    (or a TimeoutException if none is specified) if it is not realized in `interval` ms.  Returns


### PR DESCRIPTION
This adds a `deferred/alt` combinator. Naming mirrors the `core.async/alt..` functions. Also `alt` has the same length as `zip`, its dual. I find it aesthetically pleasing :) 

I find it occasionally useful. Would you consider pulling into Manifold?
