### PR TITLE
Follow-up changes to really fix #91

### DIFF
--- a/src/manifold/deferred.clj
+++ b/src/manifold/deferred.clj
@@ -356,9 +356,8 @@
              (log/warn val "unconsumed deferred in error state, make sure you're using `catch`."))))]
       nil)
 
-    clojure.lang.IMeta
-    (meta [_] mta)
     clojure.lang.IReference
+    (meta [_] mta)
     (resetMeta [_ m]
       (utils/with-lock* lock
         (set! mta m)))
@@ -446,9 +445,8 @@
    ^:volatile-mutable mta
    ^Executor executor]
 
-  clojure.lang.IMeta
-  (meta [_] mta)
   clojure.lang.IReference
+  (meta [_] mta)
   (resetMeta [_ m]
     (set! mta m))
   (alterMeta [this f args]
@@ -504,9 +502,8 @@
             debug/*dropped-error-logging-enabled?*)
       (log/warn error "unconsumed deferred in error state, make sure you're using `catch`.")))
 
-  clojure.lang.IMeta
-  (meta [_] mta)
   clojure.lang.IReference
+  (meta [_] mta)
   (resetMeta [_ m]
     (set! mta m))
   (alterMeta [this f args]

--- a/src/manifold/deferred.clj
+++ b/src/manifold/deferred.clj
@@ -356,7 +356,7 @@
              (log/warn val "unconsumed deferred in error state, make sure you're using `catch`."))))]
       nil)
 
-    clojure.lang.IObj
+    clojure.lang.IMeta
     (meta [_] mta)
     clojure.lang.IReference
     (resetMeta [_ m]
@@ -446,7 +446,7 @@
    ^:volatile-mutable mta
    ^Executor executor]
 
-  clojure.lang.IObj
+  clojure.lang.IMeta
   (meta [_] mta)
   clojure.lang.IReference
   (resetMeta [_ m]
@@ -504,7 +504,7 @@
             debug/*dropped-error-logging-enabled?*)
       (log/warn error "unconsumed deferred in error state, make sure you're using `catch`.")))
 
-  clojure.lang.IObj
+  clojure.lang.IMeta
   (meta [_] mta)
   clojure.lang.IReference
   (resetMeta [_ m]

--- a/src/manifold/stream/core.clj
+++ b/src/manifold/stream/core.clj
@@ -143,7 +143,6 @@
        ~(vec (distinct (concat params source-params)))
        manifold.stream.core.IEventStream
        manifold.stream.core.IEventSource
-       clojure.lang.IObj
        clojure.lang.IReference
        ~@(merged-body default-stream-impls default-source-impls body))
 
@@ -157,7 +156,6 @@
        ~(vec (distinct (concat params sink-params)))
        manifold.stream.core.IEventStream
        manifold.stream.core.IEventSink
-       clojure.lang.IObj
        clojure.lang.IReference
        ~@(merged-body default-stream-impls default-sink-impls body))
 
@@ -172,7 +170,6 @@
        manifold.stream.core.IEventStream
        manifold.stream.core.IEventSink
        manifold.stream.core.IEventSource
-       clojure.lang.IObj
        clojure.lang.IReference
        ~@(merged-body default-stream-impls default-sink-impls default-source-impls body))
 

--- a/test/manifold/stream_test.clj
+++ b/test/manifold/stream_test.clj
@@ -35,6 +35,9 @@
     (alter-meta! source assoc 3 4)
     (is (= {1 2 3 4} (meta source)))
 
+    (is (thrown? ClassCastException (with-meta source {})))
+    (is (thrown? ClassCastException (with-meta sink {})))
+
     (future
       (doseq [x vs]
         (try


### PR DESCRIPTION
I went to use the latest alpha release and realized I hadn't covered all the bases with regards to cleaning out instances of `IObj` being used instead of `IMeta` or `IReference`. I've done a more thorough sweep of those (`git grep IObj` returns nothing now). It turns out the deferred implementations also had the same issue, so I fixed that as well. I added a test case to `manifold.stream-test` just for good measure, since there was a convenient place to do so.