### PR TITLE
consume-async does not call the close callback

### DIFF
--- a/test/manifold/stream_test.clj
+++ b/test/manifold/stream_test.clj
@@ -334,6 +334,16 @@
     (is (= true @result))
     (is (= [1 2 3 ::done] @values))))
 
+(deftest test-consume-async
+  (let [src (s/->source [1 2])
+        values (atom [])
+        result (s/consume-async #(do (swap! values conj %)
+                                     (d/success-deferred (= (count @values) 1)))
+                                src)]
+
+    (is (= [1 2] @values))
+    (is (true? (deref result 100 ::not-done)))))
+
 (deftest test-periodically
   (testing "produces with delay"
     (let [s (s/periodically 10 0 (constantly 1))]


### PR DESCRIPTION
When a `false`-yielding Deferred is returned from a `consume-async` callback, the `on-closed` of the `Callback` is never called.

As I've understood this is because the downstreams are only closed automatically when the source is drained, not when the async put yields false. It's assumed in `manifold.stream.graph` that an async put yielding false means that the downstream was closed already.
