### PR TITLE
Do not fail on default catch when not realized

### DIFF
--- a/src/manifold/deferred.clj
+++ b/src/manifold/deferred.clj
@@ -937,7 +937,8 @@
   ([x error-handler]
      (catch' x nil error-handler))
   ([x error-class error-handler]
-     (let [x (chain' x)]
+     (let [x (chain' x)
+           error? #(or (nil? error-class) (instance? error-class %))]
        (if-not (deferred? x)
 
          ;; not a deferred value, skip over it
@@ -947,7 +948,7 @@
            val x
 
            err (try
-                 (if (or (nil? error-class) (instance? error-class err))
+                 (if (error? err)
                    (chain' (error-handler err))
                    (error-deferred err))
                  (catch Throwable e
@@ -958,7 +959,7 @@
              (on-realized x
                #(success! d' %)
                #(try
-                  (if (instance? error-class %)
+                  (if (error? %)
                     (chain'- d' (error-handler %))
                     (chain'- d' (error-deferred %)))
                   (catch Throwable e

--- a/test/manifold/deferred_test.clj
+++ b/test/manifold/deferred_test.clj
@@ -58,6 +58,10 @@
            (d/chain #(/ 1 %))
            (d/catch ArithmeticException (constantly :foo)))))
 
+  (let [d (d/deferred)]
+    (d/future (Thread/sleep 100) (d/error! d :bar))
+    (is (= :foo @(d/catch d (constantly :foo)))))
+
   (is (= :foo
         @(-> (d/error-deferred :bar)
            (d/catch (constantly :foo)))))


### PR DESCRIPTION
Missed a case while fixing #116 