### PR TITLE
Handle reduced values in stream/reduce

### DIFF
--- a/src/manifold/stream.clj
+++ b/src/manifold/stream.clj
@@ -715,7 +715,10 @@
       (source-only s'))))
 
 (defn reduce
-  "Equivalent to Clojure's `reduce`, but returns a deferred representing the return value."
+  "Equivalent to Clojure's `reduce`, but returns a deferred representing the return value.
+
+  The deferred will be realized once the stream is closed or if the accumulator
+  functions returns a `reduced` value."
   ([f s]
     (reduce f ::none s))
   ([f initial-value s]
@@ -731,7 +734,10 @@
                (d/chain' (fn [x]
                            (if (identical? ::none x)
                              val
-                             (d/recur (f val x)))))))))))))
+                             (let [r (f val x)]
+                               (if (reduced? r)
+                                 (deref r)
+                                 (d/recur r))))))))))))))
 
 (defn mapcat
   "Equivalent to Clojure's `mapcat`, but for streams instead of sequences."

--- a/test/manifold/stream_test.clj
+++ b/test/manifold/stream_test.clj
@@ -182,7 +182,17 @@
         @(s/reduce + (s/->source inputs))))
     (is
       (= (reduce + 1 inputs)
-        @(s/reduce + 1 (s/->source inputs))))))
+        @(s/reduce + 1 (s/->source inputs)))))
+
+  (let [inputs (range 10)
+        accf (fn [acc el]
+               (if (= el 5) (reduced :large) el))
+        s (s/->source inputs)]
+    (is (= :large
+           (reduce accf 0 inputs)
+           @(s/reduce accf 0 s)))
+    (is (not (s/drained? s)))
+    (is (= 6 @(s/try-take! s 1)))))
 
 (deftest test-zip
   (let [inputs (partition-all 1e4 (range 3e4))]


### PR DESCRIPTION
This makes the `manifold.stream/reduce` respect the `reduced` values. The deferred result of `stream/reduce` will be completed with the reduced value. 

This is a breaking change, however the behaviour it breaks probably wasn't correct in the first place as we'd expect this function to work similar to the `clojure.core/reduce`.

What do you think?