### PR TITLE
Do not deadlock on exception during first execution in mock-clock

### DIFF
--- a/test/manifold/time_test.clj
+++ b/test/manifold/time_test.clj
@@ -53,3 +53,15 @@
         (cancel)
         (t/advance c 5)
         (is (= 10 @n))))))
+
+(deftest test-mock-clock-deschedules-after-exception
+  (let [c (t/mock-clock 0)
+        counter (atom 0)]
+    (t/with-clock c
+      (t/every 1
+        (fn []
+          (swap! counter inc)
+          (throw (Exception. "BOOM")))))
+    (is (= 1 @counter))
+    (t/advance c 1)
+    (is (= 1 @counter))))


### PR DESCRIPTION
I only thought of a way to make this work by changing the contract of `IClock#every` - now it is supposed to wrap the passed-in function into a self-cancelling runnable.

Before this change the attached `test-mock-clock-deschedules-after-exception` deadlocks on the first `every` execution. The exception handling code waits for the return value of `every` which never happens as it's running on the same thread.