### PR TITLE
Do not execute let-flow body within the last deferred thread (fixes #156)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject manifold "0.1.8"
+(defproject manifold "0.1.9-SNAPSHOT"
   :description "a compatibility layer for event-driven abstractions"
   :license {:name "MIT License"
             :url "http://opensource.org/licenses/MIT"}

--- a/src/manifold/deferred.clj
+++ b/src/manifold/deferred.clj
@@ -1315,7 +1315,7 @@
                               (concat (drop (count vars) gensyms))
                               set)
         dep?                (set/union binding-dep? body-dep?)]
-    `(let [executor# (manifold.executor/executor)]
+    `(let [executor# (or (manifold.executor/executor) (ex/execute-pool))]
        (manifold.executor/with-executor nil
          (let [~@(mapcat
                    (fn [n var val gensym]
@@ -1331,10 +1331,9 @@
                    vars'
                    vals'
                    gensyms)]
-           (~chain-fn (~zip-fn ~@body-dep?)
+           (~chain-fn (d/onto (~zip-fn ~@body-dep?) executor#)
             (fn [[~@(map gensym->var body-dep?)]]
-              (manifold.executor/with-executor executor#
-                ~@body))))))))
+              ~@body)))))))
 
 (defmacro let-flow
   "A version of `let` where deferred values that are let-bound or closed over can be treated


### PR DESCRIPTION
Here is my attempt at fixing #156. I've been thinking a bit about this issue and I agree that the behaviour isn't what one would expect. So here is my try at making sure the body of let-flow isn't using the last deferred thread. From what I understand of commit 193f5f48972c8e20dd0a9fc41a1311566a9f7bdd that was the intended goal.

Let-flow body should not be executed within the last deferred thread as it may exhaust a thread pool if the body computation is extensive. This commit ensures that the body is executed either within the executor specified through with-executor or on the default execute-pool.