### PR TITLE
Extend functionality of the thread-factory builder

### DIFF
--- a/src/manifold/executor.clj
+++ b/src/manifold/executor.clj
@@ -41,6 +41,7 @@
     (reify ThreadFactory
       (newThread [_ runnable]
         (let [name (name-generator)
+              curr-loader (.getClassLoader (class thread-factory))
               f #(do
                    (.set executor-thread-local @executor-promise)
                    (.run ^Runnable runnable))]
@@ -48,7 +49,8 @@
             (if stack-size
               (Thread. nil f name stack-size)
               (Thread. nil f name))
-            (.setDaemon daemon?)))))))
+            (.setDaemon daemon?)
+            (.setContextClassLoader curr-loader)))))))
 
 ;;;
 

--- a/src/manifold/executor.clj
+++ b/src/manifold/executor.clj
@@ -34,8 +34,10 @@
 
 (defn ^ThreadFactory thread-factory
   ([name-generator executor-promise]
-     (thread-factory name-generator executor-promise nil))
+   (thread-factory name-generator executor-promise nil true))
   ([name-generator executor-promise stack-size]
+   (thread-factory name-generator executor-promise stack-size true))
+  ([name-generator executor-promise stack-size daemon?]
     (reify ThreadFactory
       (newThread [_ runnable]
         (let [name (name-generator)
@@ -46,7 +48,7 @@
             (if stack-size
               (Thread. nil f name stack-size)
               (Thread. nil f name))
-            (.setDaemon true)))))))
+            (.setDaemon daemon?)))))))
 
 ;;;
 

--- a/test/manifold/executor_test.clj
+++ b/test/manifold/executor_test.clj
@@ -7,7 +7,10 @@
      Executor
      Executor$Controller]
     [java.util.concurrent
-     LinkedBlockingQueue]))
+     ExecutorService
+     Executors
+     LinkedBlockingQueue
+     ThreadFactory]))
 
 (deftest test-instrumented-executor-uses-thread-factory
   (let [thread-count (atom 0)
@@ -24,3 +27,16 @@
         thread-names (LinkedBlockingQueue. 1)]
     (.execute ^Executor executor #(.put thread-names (.getName (Thread/currentThread))))
     (is (contains? #{(str threadpool-prefix 1) (str threadpool-prefix 2)} (.take thread-names)))))
+
+(deftest test-rt-dynamic-classloader
+  (let [num-threads (atom 0)
+        in-thread-loader (promise)
+        tf (e/thread-factory
+            #(str "my-loader-prefix-" (swap! num-threads inc))
+            (deliver (promise) nil))
+        executor (Executors/newFixedThreadPool 1 ^ThreadFactory tf)]
+    (.execute ^ExecutorService executor
+              (fn []
+                (let [l (clojure.lang.RT/baseLoader)]
+                  (deliver in-thread-loader l))))
+    (is (instance? clojure.lang.DynamicClassLoader @in-thread-loader))))


### PR DESCRIPTION
There're 2 different extensions here:

1. `daemon?` configuration, backward compatible with old usage patterns. We need this to use `executor/thread-factory` in Aleph project (as we need both daemon and non-daemon threads there).

2. Set context class loader for each new thread. More info [here](https://github.com/ztellman/aleph/pull/425). That's actually done in a kinda "defensive" style. Those threads would have context class loader set to a parent thread loader... in most cases. So we're kinda safe here using `RT.baseLoader` in Aleph that falls back to a current thread class loader at least with the default configuration and with runtime class loading path the ignores "non-Clojure" class loaders. I prefer to left the assignment here to workaround different behavior of security manager that might prevent referencing to the parent class loader. We still can have a problem with `*use-context-classloader*` set to `false`, but that's something you have to do manually. And I hope in such a case the user understands the reasons and consequences.   