### PR TITLE
declare core.async as scope "provided" dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,10 +5,10 @@
   :url "https://github.com/ztellman/manifold"
   :dependencies [[org.clojure/tools.logging "0.3.1" :exclusions [org.clojure/clojure]]
                  [io.aleph/dirigiste "0.1.6-alpha1"]
+                 [org.clojure/core.async "0.4.474" :scope "provided"]
                  [riddley "0.1.15"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
-                                  [criterium "0.4.4"]
-                                  [org.clojure/core.async "0.4.474"]]}}
+                                  [criterium "0.4.4"]]}}
   :test-selectors {:default #(not
                                (some #{:benchmark :stress}
                                  (cons (:tag %) (keys %))))


### PR DESCRIPTION
core.async is currently listed in the jar with `:scope "test"` but it seems that `:scope "provided"` might be more appropriate since core.async is also an optional runtime dependency.

This is useful for tools that want to analyze Manifolds jar (like https://cljdoc.org) and need to construct a classpath that contains all dependencies needed to load all namespaces.

The better separation between `provided` and `test` allows such tools not to add testing related dependencies to the classpath.

---

PS. There are docs for [Manifold on cljdoc](https://cljdoc.org/d/manifold). If you want to use those consider adding the following to your Readme (note that [previous versions](https://cljdoc.org/versions/manifold/manifold) are also available):

```
[![](https://cljdoc.org/badge/manifold)](https://cljdoc.org/d/manifold)
```
[![](https://cljdoc.org/badge/manifold)](https://cljdoc.org/d/manifold)
