### PR TITLE
tests: allow a bit more time for JDK7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ jdk:
   - openjdk7
   - openjdk8
   - openjdk9
+  - openjdk11

--- a/project.clj
+++ b/project.clj
@@ -25,6 +25,5 @@
   :global-vars {*warn-on-reflection* true}
   :jvm-opts ^:replace ["-server"
                        "-XX:-OmitStackTraceInFastThrow"
-                       "-XX:+UseConcMarkSweepGC"
                        "-Xmx2g"
                        "-XX:NewSize=1g"])

--- a/test/manifold/stream_test.clj
+++ b/test/manifold/stream_test.clj
@@ -389,8 +389,8 @@
 
 (deftest test-periodically
   (testing "produces with delay"
-    (let [s (s/periodically 10 0 (constantly 1))]
-      (Thread/sleep 15)
+    (let [s (s/periodically 20 0 (constantly 1))]
+      (Thread/sleep 30)
       (s/close! s)
       ;; will produces 2 items here no matter the sleep amount
       ;; as the periodically stream has a buffer of 1


### PR DESCRIPTION
#170 and master fail on a timing issue, this patch does two things:

- Give the JVM a bit more time to breathe
- Remove deprecated GC option on newer JDKs
- Add OpenJDK11 a common build target

This should restore green builds