### PR TITLE
Fix issue with listeners not being cleaned up in alt'

### DIFF
--- a/src/manifold/deferred.clj
+++ b/src/manifold/deferred.clj
@@ -1115,10 +1115,16 @@
             (success-error-unrealized x
               val (success! d val)
               err (error! d err)
-              (do (on-realized (chain' x)
-                    #(success! d %)
-                    #(error! d %))
-                  (recur (inc i))))
+              (let [l (listener #(success! d %)
+                                #(error! d %))]
+                (add-listener! x l)
+                (on-realized d
+                             (fn [&args]
+                               (cancel-listener! x l))
+                             (fn [&args]
+                               (cancel-listener! x l)))
+
+                (recur (inc i))))
             (success! d x)))))
     d))
 


### PR DESCRIPTION
The current implementation of alt' has a bug where it doesn't clean up previous listeners once one of the deferreds have resolved. 

This problem can be shown using the following code:

```

(def control-chan (md/deferred))
(def x (md/deferred))

(def y (alt control-chan x))
(md/success! x {:foo :bar})

(println "control chan listeners: " (pr-str (.-listeners control-chan))))
```

You will see that, even though both `x` and `y` have realized, the listener on `control-chan` is still there. If you repeat this block of code many times, many listeners will remain active (we kept running into tens of thousands of runaway listeners).

This PR addresses this problem, by using listeners instead. Upon realization of the deferred returned by `alt'`, it cancels all outstanding listeners.