### PR TITLE
Fix dropped errors in `manifold.deferred/timeout!`

### DIFF
--- a/src/manifold/deferred.clj
+++ b/src/manifold/deferred.clj
@@ -1293,9 +1293,12 @@
      (let [timeout-d (time/in interval
                               #(error! d
                                        (TimeoutException.
-                                         (str "timed out after " interval " milliseconds"))))]
-       (chain d (fn [_]
-                  (success! timeout-d true)))))
+                                        (str "timed out after " interval " milliseconds"))))]
+       (on-realized d
+                    (fn [_]
+                      (success! timeout-d true))
+                    (fn [_]
+                      (success! timeout-d false)))))
    d)
   ([d interval timeout-value]
    (cond
@@ -1308,8 +1311,11 @@
      :else
      (let [timeout-d (time/in interval
                               #(success! d timeout-value))]
-       (chain d (fn [_]
-                  (success! timeout-d true)))))
+       (on-realized d
+                    (fn [_]
+                      (success! timeout-d true))
+                    (fn [_]
+                      (success! timeout-d false)))))
    d))
 
 (deftype+ Recur [s]


### PR DESCRIPTION
When putting the result deferred `d` in an error state, deferred returned by `chain` would be detected as a dropped error because it's only used to attach a side-effecting callback for cancelling the timeout. The fix then is to use `on-realized` instead to attach a handler for both cases. As a consequence, timeouts are now also properly cancelled when the result deferred is put in an error state, freeing up resources in a more timely fashion.

This fixes one of the causes of https://github.com/clj-commons/aleph/issues/766, as well as 2 of the 3 dropped errors in `manifold.go-off-test`.

Also, add dedicated tests for `d/timeout!`.

Based on #245.