### PR TITLE
Always run chained callbacks on deferred's executor

### DIFF
--- a/src/manifold/executor.clj
+++ b/src/manifold/executor.clj
@@ -18,6 +18,8 @@
      ThreadFactory
      TimeUnit]))
 
+(set! *warn-on-reflection* true)
+
 ;;;
 
 (def ^ThreadLocal executor-thread-local (ThreadLocal.))
@@ -58,7 +60,7 @@
      (.set current-executor-thread-local executor)
      (.run ^Runnable runnable)))
 
-(defn- wrap-thread-factory [tf executor-promise]
+(defn- wrap-thread-factory [^ThreadFactory tf executor-promise]
   (reify ThreadFactory
     (newThread [_ runnable]
       (.newThread tf (wrap-thread-runnable runnable executor-promise)))))
@@ -75,7 +77,7 @@
    | `onto?` | if true, all streams and deferred generated in the scope of this executor will also be 'on' this executor. |"
   ([executor]
    (wrap-executor executor {}))
-  ([executor
+  ([^java.util.concurrent.Executor executor
     {:keys [thread-factory
             onto?]
      :or   {onto? true}}]
@@ -83,7 +85,7 @@
      executor
      (let [executor-promise (promise)
            wrapped-executor (if thread-factory
-                              (let [executor (executor (wrap-thread-factory thread-factory executor-promise))]
+                              (let [^java.util.concurrent.Executor executor (executor (wrap-thread-factory thread-factory executor-promise))]
                                 (reify java.util.concurrent.Executor
                                   (execute [_ runnable]
                                     (.execute executor runnable))

--- a/src/manifold/stream.clj
+++ b/src/manifold/stream.clj
@@ -1131,11 +1131,13 @@
      (connect-via
        source
        (fn [val]
-         (d/let-flow [put-result (try-put! sink val 0 ::timeout)]
-           (case put-result
-             true     true
-             false    false
-             ::timeout true)))
+         (d/chain'
+          (try-put! sink val 0 ::timeout)
+          (fn [put-result]
+            (case put-result
+              true     true
+              false    false
+              ::timeout true))))
        sink
        {:upstream?   true
         :downstream? true})
@@ -1159,7 +1161,7 @@
        source
        (fn [val]
          (d/loop []
-           (d/chain
+           (d/chain'
              (try-put! sink val 0 ::timeout)
              (fn [put-result]
                (case put-result

--- a/test/manifold/stream_test.clj
+++ b/test/manifold/stream_test.clj
@@ -466,16 +466,23 @@
     (is (s/closed? sink))
     (is (s/closed? src))))
 
+(defn await-drained [s timeout]
+  (let [d (d/deferred)]
+    (s/on-drained s (fn [] (d/success! d true)))
+    (deref d timeout false)))
+
 (deftest test-window-streams
   (testing "dropping-stream"
     (let [s (s/->source (range 11))
           dropping-s (s/dropping-stream 10 s)]
+      (is (await-drained s 100))
       (is (= (range 10)
              (s/stream->seq dropping-s)))))
 
   (testing "sliding-stream"
     (let [s (s/->source (range 11))
           sliding-s (s/sliding-stream 10 s)]
+      (is (await-drained s 100))
       (is (= (range 1 11)
              (s/stream->seq sliding-s))))))
 


### PR DESCRIPTION
Addresses #151 by implementing @ztellman's idea from https://github.com/clj-commons/manifold/issues/151#issuecomment-1452583334. I decided to split this up into three main commits:

1. Extract a helper function (`execute-callback`) for executing chained callbacks and use it in all places where we have to decide whether to invoke the callback directly or whether to hand it off to the executor.
2. Modify chaining functions to always execute callbacks on a deferred's executor even when already realized
3. Keep track of the current executor and make `execute-callback` execute callbacks directly when the given executor is the same as the current one.

I also tried to add tests for all of this. See individual commits for more details. The other commits are small collateral changes.

The only major missing piece is this:

> add a mechanism in `manifold.executor` for wrapping a preexisting executor such that submitted `Runnable`s are wrapped with thread-local handlers (ideally this will be idempotent and not double-wrap executors like `instrumented-executor` which already has the necessary stuff)

Not quite sure how to do this, yet. Maybe via `proxy`? Suggestions welcome.

UPDATE: Just pushed two more commits to provide an API for wrapping existing executors.